### PR TITLE
Fix typos in quick.ipynb

### DIFF
--- a/tensorflow_fold/g3doc/quick.ipynb
+++ b/tensorflow_fold/g3doc/quick.ipynb
@@ -185,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One useful thing you can do with blocks is wire them up to create pipelines using the `>>` operator, which performs function composition. For example, we can take our tuple two tensors and compose it with `Concat`, like so:"
+    "One useful thing you can do with blocks is wire them up to create pipelines using the `>>` operator, which performs function composition. For example, we can take our two tuple tensors and compose it with `Concat`, like so:"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that because Python dicts are unordered, Fold always sorts the outputs of a record block by dictionary key. If you want preserve order you can construct a Record block from an OrderedDict.\n",
+    "Note that because Python dicts are unordered, Fold always sorts the outputs of a record block by dictionary key. If you want to preserve order you can construct a Record block from an OrderedDict.\n",
     "\n",
     "The whole point of Fold is to get your data into TensorFlow; the `Function` block lets you convert a TITO (Tensors In, Tensors Out) function to a block:"
    ]
@@ -497,9 +497,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `reduce_net_block` function creates a block (`net_block` that contains a two-layer fully connected (FC) network that takes a pair of scalar tensors as input and produces a scalar tensor as output. This network gets applied in a binary tree to reduce a sequence of scalar tensors to a single scalar tensor.\n",
+    "The `reduce_net_block` function creates a block (`net_block`) that contains a two-layer fully connected (FC) network that takes a pair of scalar tensors as input and produces a scalar tensor as output. This network gets applied in a binary tree to reduce a sequence of scalar tensors to a single scalar tensor.\n",
     "\n",
-    "One thing to notice here is that we are calling [`tf.squeeze`](https://www.tensorflow.org/versions/r1.0/api_docs/python/array_ops/shapes_and_shaping#squeeze) with `axis=1`, even though the Fold output type of `td.FC(1, activation=None)` (and hence the input type of the enclosing `Function` block) is a `TensorType` with shape `(1)`). This is because all Fold blocks actually run on TF tensors with an implicit leading batch dimension, which enables execution via [*dynamic batching*](https://arxiv.org/abs/1702.02181). It is important to bear this in mind when creating `Function` blocks that wrap functions that are not applied elementwise."
+    "One thing to notice here is that we are calling [`tf.squeeze`](https://www.tensorflow.org/versions/r1.0/api_docs/python/array_ops/shapes_and_shaping#squeeze) with `axis=1`, even though the Fold output type of `td.FC(1, activation=None)` (and hence the input type of the enclosing `Function` block) is a `TensorType` with shape `(1)`. This is because all Fold blocks actually run on TF tensors with an implicit leading batch dimension, which enables execution via [*dynamic batching*](https://arxiv.org/abs/1702.02181). It is important to bear this in mind when creating `Function` blocks that wrap functions that are not applied elementwise."
    ]
   },
   {
@@ -521,7 +521,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `random_example` function generates training data consisting of `(example, fn(example)` pairs, where `example` is a random list of numbers, e.g.:"
+    "The `random_example` function generates training data consisting of `(example, fn(example))` pairs, where `example` is a random list of numbers, e.g.:"
    ]
   },
   {
@@ -678,7 +678,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Breaking news; deep neural network learns to calculate 1 + 1!!!!"
+    "Breaking news: deep neural network learns to calculate 1 + 1!!!!"
    ]
   },
   {
@@ -752,7 +752,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Oh noes! What went wrong? Note that we trained our network to compute `min` on positive numbers; negative numbers are outside of it's input distribution."
+    "Oh noes! What went wrong? Note that we trained our network to compute `min` on positive numbers; negative numbers are outside of its input distribution."
    ]
   },
   {


### PR DESCRIPTION
Fixed some distracting issues with missing closing parentheses and other minor spelling/grammar issues.