### PR TITLE
Use ndarray.tostring rather than tobytes for numpy 1.8 compatibility

### DIFF
--- a/tensorflow_fold/loom/loom.py
+++ b/tensorflow_fold/loom/loom.py
@@ -962,7 +962,7 @@ class Weaver(object):
     else:
       # Send raw bytes rather than TensorProto because make_tensor_proto
       # is very slow, taking e.g. 35 usec for a vector of 10 float32s.
-      constant = self._weaver.MakeConstantSerialized(ts_idx, value.tobytes())
+      constant = self._weaver.MakeConstantSerialized(ts_idx, value.tostring())
     if constant == -1:
       raise AssertionError('Weaver Constant creation failed: %s' %
                            self._weaver.error_string())


### PR DESCRIPTION
In Python 3, `tostring` still converts to `bytes`.